### PR TITLE
fix: add database_name override

### DIFF
--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -11,5 +11,6 @@ module "init" {
 module "postgresql" {
   source     = "github.com/entur/terraform-google-sql-db//modules/postgresql?ref=v0.0.1"
   init       = module.init
+  databases  = ["my-database"]
 }
 # ci: x-release-please-end

--- a/examples/minimal_test/main.tf
+++ b/examples/minimal_test/main.tf
@@ -23,4 +23,6 @@ module "postgresql" {
   init       = module.init
   #init       = var.init
   generation = random_integer.random_database_generation.result
+  databases = [ "my-database", "another-database"] 
 }
+

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -40,6 +40,7 @@ No modules.
 | <a name="input_init"></a> [init](#input\_init) | Entur init module output. https://github.com/entur/terraform-google-init. Used to determine application name, application project, labels, and resource names. | <pre>object({<br>    app = object({<br>      id         = string<br>      name       = string<br>      owner      = string<br>      project_id = string<br>    })<br>    environment   = string<br>    labels        = map(string)<br>    is_production = bool<br>  })</pre> | n/a | yes |
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | REGIONAL or ZONAL database. | `string` | `"REGIONAL"` | no |
 | <a name="input_backup_start_time"></a> [backup\_start\_time](#input\_backup\_start\_time) | Start time in UTC for daily backup job in the format HH:MM. This is the start time of a 4 hour time window. | `string` | `"00:00"` | no |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The name of the database. Defaults to init.app.name. | `string` | `null` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The postgres database version. | `string` | `"POSTGRES_13"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Enable backup for database. | `bool` | `null` | no |
 | <a name="input_disable_offsite_backup"></a> [disable\_offsite\_backup](#input\_disable\_offsite\_backup) | Disable offsite backup for this database. Offsite backup is only applied to prd. | `bool` | `false` | no |

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -37,10 +37,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_databases"></a> [databases](#input\_databases) | The databases to create. | `list(string)` | n/a | yes |
 | <a name="input_init"></a> [init](#input\_init) | Entur init module output. https://github.com/entur/terraform-google-init. Used to determine application name, application project, labels, and resource names. | <pre>object({<br>    app = object({<br>      id         = string<br>      name       = string<br>      owner      = string<br>      project_id = string<br>    })<br>    environment   = string<br>    labels        = map(string)<br>    is_production = bool<br>  })</pre> | n/a | yes |
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | REGIONAL or ZONAL database. | `string` | `"REGIONAL"` | no |
 | <a name="input_backup_start_time"></a> [backup\_start\_time](#input\_backup\_start\_time) | Start time in UTC for daily backup job in the format HH:MM. This is the start time of a 4 hour time window. | `string` | `"00:00"` | no |
-| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The name of the database. Defaults to init.app.name. | `string` | `null` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The postgres database version. | `string` | `"POSTGRES_13"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Enable backup for database. | `bool` | `null` | no |
 | <a name="input_disable_offsite_backup"></a> [disable\_offsite\_backup](#input\_disable\_offsite\_backup) | Disable offsite backup for this database. Offsite backup is only applied to prd. | `bool` | `false` | no |
@@ -59,7 +59,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Name of the default database in the database instance. |
+| <a name="output_databases"></a> [databases](#output\_databases) | Databases created on this instance. |
 | <a name="output_init"></a> [init](#output\_init) | The init module used in the module. |
 | <a name="output_instance"></a> [instance](#output\_instance) | The database instance output, as described in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance. |
 | <a name="output_kubernetes_namespace"></a> [kubernetes\_namespace](#output\_kubernetes\_namespace) | Name of the kubernetes namespace where the connection details configmap and secret are deployed. |

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -1,5 +1,4 @@
 locals {
-  database_name         = var.database_name != null ? var.database_name : var.init.app.name
   retained_backups      = var.retained_backups != null ? var.retained_backups : var.init.is_production ? 30 : 7
   deletion_protection   = var.deletion_protection != null ? var.deletion_protection : var.init.is_production ? true : false
   offsite_backup_label  = var.disable_offsite_backup == true && var.init.is_production ? { label_backup_offsite = false } : {} # Add the label for opt-out of offsite backup in prod environments when disable_offsite_backup is true
@@ -45,7 +44,8 @@ resource "google_sql_database_instance" "main" {
 }
 
 resource "google_sql_database" "main" {
-  name     = local.database_name
+  for_each = toset(var.databases)
+  name     = each.key
   project  = var.init.app.project_id
   instance = google_sql_database_instance.main.name
 }

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -1,4 +1,5 @@
 locals {
+  database_name         = var.database_name != null ? var.database_name : var.init.app.name
   retained_backups      = var.retained_backups != null ? var.retained_backups : var.init.is_production ? 30 : 7
   deletion_protection   = var.deletion_protection != null ? var.deletion_protection : var.init.is_production ? true : false
   offsite_backup_label  = var.disable_offsite_backup == true && var.init.is_production ? { label_backup_offsite = false } : {} # Add the label for opt-out of offsite backup in prod environments when disable_offsite_backup is true
@@ -44,7 +45,7 @@ resource "google_sql_database_instance" "main" {
 }
 
 resource "google_sql_database" "main" {
-  name     = var.init.app.name
+  name     = local.database_name
   project  = var.init.app.project_id
   instance = google_sql_database_instance.main.name
 }

--- a/modules/postgresql/outputs.tf
+++ b/modules/postgresql/outputs.tf
@@ -17,9 +17,9 @@ output "instance" {
   value       = google_sql_database_instance.main
 }
 
-output "database_name" {
-  description = "Name of the default database in the database instance."
-  value       = google_sql_database.main.name
+output "databases" {
+  description = "Databases created on this instance."
+  value       = var.databases
 }
 
 output "kubernetes_namespace" {

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -46,6 +46,12 @@ variable "generation" {
   }
 }
 
+variable "database_name" {
+  description = "The name of the database. Defaults to init.app.name."
+  type        = string
+  default     = null
+}
+
 variable "database_version" {
   description = "The postgres database version."
   type        = string

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -46,10 +46,9 @@ variable "generation" {
   }
 }
 
-variable "database_name" {
-  description = "The name of the database. Defaults to init.app.name."
-  type        = string
-  default     = null
+variable "databases" {
+  description = "The databases to create."
+  type        = list(string)
 }
 
 variable "database_version" {


### PR DESCRIPTION
Some (most?) databases do not follow the app name convention. `pos-register` => `posregister` as an example.