### PR TITLE
fix: force tcp for proxy

### DIFF
--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -67,7 +67,7 @@ resource "kubernetes_config_map" "main_psql_connection" {
   }
 
   data = {
-    INSTANCES = google_sql_database_instance.main.connection_name
+    INSTANCES = "${google_sql_database_instance.main.connection_name}=tcp:5432"
   }
 }
 resource "random_integer" "password_length" {


### PR DESCRIPTION
INSTANCES is passed directly to sql proxy, and the connection string must (at least in the past) reflect this by adding a TCP suffix to the string. 