### PR TITLE
Support specifying database-flags for custom configuration

### DIFF
--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -55,6 +55,13 @@ resource "google_sql_database_instance" "main" {
       record_client_address   = var.query_insights_config.record_client_address
       record_application_tags = var.query_insights_config.record_application_tags
     }
+    dynamic "database_flags" {
+      for_each = var.database_flags
+      content {
+        name  = database_flags.value.name
+        value = database_flags.value.value
+      }
+    }
   }
 
   deletion_protection = local.deletion_protection

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -196,6 +196,15 @@ variable "query_insights_config" {
   }
 }
 
+variable "database_flags" {
+  description = "Override default CloudSQL configuration by specifying database-flags."
+  type = map(object({
+    name  = string
+    value = string
+  }))
+  default = {}
+}
+
 variable "create_kubernetes_resources" {
   description = "Optionally disables creating k8s resources -psql-connection and -psql-credentials. Can be used to avoic overwriting existing resources on database creation."
   type        = bool


### PR DESCRIPTION
Currently, changes made to database-flags in the console-ui is reverted by a terraform apply. Which means flags need to be specified in code to be permanent.

Note: There is some sort of ordering of the flags (in the backend/api) that cannot be replicated using terraform, so the may be a diff when setting the exact same flags in code as is already specified in the ui for the instance (see screenshot)

When database-flags is added directly in the consule-ui, terraform will try to remove on next apply as visible here:
![Screenshot 2022-12-09 at 14 39 07](https://user-images.githubusercontent.com/172572/206995453-f1136d6c-d201-4646-b0cf-1ea3720a64ef.png)

Weird ordering/sorting issue when applying the exact config as already present:
![Screenshot 2022-12-12 at 09 12 18](https://user-images.githubusercontent.com/172572/206995673-2d84565e-d373-48b2-a578-0794f9533022.png)

However, if we apply this diff the plan stabilizes (next plan output):

```
No changes. Infrastructure is up-to-date.
```
