### PR TITLE
feat: New module postgresql-replica

### DIFF
--- a/.github/workflows/pr-tests-terraform.yml
+++ b/.github/workflows/pr-tests-terraform.yml
@@ -13,4 +13,4 @@ jobs:
   tf-tests:
     uses: entur/gh-workflows/.github/workflows/pr-tests-terraform.yml@main
     with:
-      module_dirs: '["./modules/postgresql"]'
+      module_dirs: '["./modules/postgresql","./modules/postgresql-replica"]'

--- a/modules/postgresql-replica/.terraform-docs.yml
+++ b/modules/postgresql-replica/.terraform-docs.yml
@@ -1,0 +1,3 @@
+sort:
+  enabled: true
+  by: required

--- a/modules/postgresql-replica/README.md
+++ b/modules/postgresql-replica/README.md
@@ -1,0 +1,78 @@
+# Postgres Terraform Module #
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >=4.26.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.3 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >=4.26.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_sql_database.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
+| [google_sql_database_instance.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
+| [google_sql_user.additional_users](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
+| [google_sql_user.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
+| [kubernetes_config_map.main_psql_connection](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
+| [kubernetes_secret.additional_database_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.main_database_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [random_integer.additional_users_password_length](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
+| [random_integer.password_length](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
+| [random_password.additional_users_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_databases"></a> [databases](#input\_databases) | Names of databases to create. | `list(string)` | n/a | yes |
+| <a name="input_init"></a> [init](#input\_init) | Entur init module output. https://github.com/entur/terraform-google-init. Used to determine application name, application project, labels, and resource names. | <pre>object({<br>    app = object({<br>      id         = string<br>      name       = string<br>      owner      = string<br>      project_id = string<br>    })<br>    environment   = string<br>    labels        = map(string)<br>    is_production = bool<br>  })</pre> | n/a | yes |
+| <a name="input_additional_users"></a> [additional\_users](#input\_additional\_users) | A list of user-names in addition to the main user that should be created. | <pre>map(object({<br>    username                 = string<br>    create_kubernetes_secret = bool<br>  }))</pre> | `{}` | no |
+| <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | Whether to enable high availability with automatic failover over multiple zones ('REGIONAL') vs. single zone ('ZONAL'). | `string` | `null` | no |
+| <a name="input_backup_start_time"></a> [backup\_start\_time](#input\_backup\_start\_time) | Start time in UTC for daily backup job in the format HH:MM. This is the start time of a 4 hour time window. | `string` | `"00:00"` | no |
+| <a name="input_create_kubernetes_resources"></a> [create\_kubernetes\_resources](#input\_create\_kubernetes\_resources) | Optionally disables creating k8s resources -psql-connection and -psql-credentials. Can be used to avoic overwriting existing resources on database creation. | `bool` | `true` | no |
+| <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | Override default CloudSQL configuration by specifying database-flags. | <pre>map(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `{}` | no |
+| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The PostgreSQL version (see https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version). | `string` | `"POSTGRES_14"` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `bool` | `null` | no |
+| <a name="input_disable_offsite_backup"></a> [disable\_offsite\_backup](#input\_disable\_offsite\_backup) | Disable offsite backup for this instance. Offsite backup is only applied to production environments. | `bool` | `false` | no |
+| <a name="input_disk_autoresize"></a> [disk\_autoresize](#input\_disk\_autoresize) | Whether to enable auto-resizing of the storage disk. | `bool` | `true` | no |
+| <a name="input_disk_autoresize_limit"></a> [disk\_autoresize\_limit](#input\_disk\_autoresize\_limit) | The maximum size an auto-resized disk can reach. Default is 500 for production, 50 for non-production. | `number` | `null` | no |
+| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | The storage disk size of the instance. Default is 10 (GB). Only takes effect if disk\_autoresize is set to 'false'. | `number` | `10` | no |
+| <a name="input_enable_backup"></a> [enable\_backup](#input\_enable\_backup) | Whether to enable daily backup of databases. | `bool` | `true` | no |
+| <a name="input_generation"></a> [generation](#input\_generation) | The generation (aka serial no.) of the instance. Starts at 1, ends at 999. Will be padded with leading zeros. | `number` | `1` | no |
+| <a name="input_machine_size"></a> [machine\_size](#input\_machine\_size) | Map of the database instance CPU count (cpu) and memory sizes in MB (memory). Optionally, set a tier override (tier). See README.md for examples. | `map` | `null` | no |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The day of the week (1-7), and hour of the day (0-24) in UTC to perform database instance maintenance. This is the start time of the one hour maintinance window. | <pre>object({<br>    day  = number<br>    hour = number<br>  })</pre> | <pre>{<br>  "day": 2,<br>  "hour": 0<br>}</pre> | no |
+| <a name="input_query_insights_config"></a> [query\_insights\_config](#input\_query\_insights\_config) | Advanced config for Query Insights. | <pre>object({<br>    query_string_length     = number<br>    record_application_tags = bool<br>    record_client_address   = bool<br>  })</pre> | <pre>{<br>  "query_string_length": 1024,<br>  "record_application_tags": false,<br>  "record_client_address": false<br>}</pre> | no |
+| <a name="input_query_insights_enabled"></a> [query\_insights\_enabled](#input\_query\_insights\_enabled) | Whether to enable query insights (7 day retention). | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | The region the instance will sit in. | `string` | `"europe-west1"` | no |
+| <a name="input_retained_backups"></a> [retained\_backups](#input\_retained\_backups) | The number of backups to retain. Default is 30 for production, 7 for non-production. | `number` | `null` | no |
+| <a name="input_transaction_log_retention_days"></a> [transaction\_log\_retention\_days](#input\_transaction\_log\_retention\_days) | How long transaction logs are stored (1-7). | `number` | `7` | no |
+| <a name="input_user_name"></a> [user\_name](#input\_user\_name) | The username of the default application user. Defaults to the app ID. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_additional_users"></a> [additional\_users](#output\_additional\_users) | Map containing the username and password for any additional users. |
+| <a name="output_databases"></a> [databases](#output\_databases) | Databases created on this instance. |
+| <a name="output_init"></a> [init](#output\_init) | The output of the consumed init module. |
+| <a name="output_instance"></a> [instance](#output\_instance) | The database instance output, as described in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance. |
+| <a name="output_kubernetes_namespace"></a> [kubernetes\_namespace](#output\_kubernetes\_namespace) | Name of the Kubernetes namespace where config maps and secrets are deployed. |
+| <a name="output_user"></a> [user](#output\_user) | Map containing the username and password of the default application user. |
+<!-- END_TF_DOCS -->

--- a/modules/postgresql-replica/README.md
+++ b/modules/postgresql-replica/README.md
@@ -32,7 +32,6 @@ No modules.
 | <a name="input_master_instance"></a> [master\_instance](#input\_master\_instance) | The master instance to create a read-replica for. Must be a 'google\_sql\_database\_instance' from either the master resource or data. | `any` | n/a | yes |
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | Whether to enable high availability with automatic failover to another read-replica. 'REGIONAL' for HA, 'ZONAL' for single zone. | `string` | `null` | no |
 | <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | Override default CloudSQL configuration by specifying database-flags. | <pre>map(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `{}` | no |
-| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `bool` | `null` | no |
 | <a name="input_machine_size_override"></a> [machine\_size\_override](#input\_machine\_size\_override) | By default, machine\_size will be the same as the master. Set this variable to override. Keep in mind that replica must have equal or higher machine\_size. See README.md for examples. | `map` | `null` | no |
 | <a name="input_replica_number"></a> [replica\_number](#input\_replica\_number) | The replica-number of the instance in the case of many. Starts at 1, ends at 999. Will be padded with leading zeros. Used as suffix for the instance-name | `number` | `1` | no |
 

--- a/modules/postgresql-replica/README.md
+++ b/modules/postgresql-replica/README.md
@@ -23,14 +23,13 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_sql_database_instance.replica](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
-| [google_sql_database_instance.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/sql_database_instance) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_init"></a> [init](#input\_init) | Entur init module output. https://github.com/entur/terraform-google-init. Used to determine application name, application project, labels, and resource names. | <pre>object({<br>    app = object({<br>      id         = string<br>      name       = string<br>      owner      = string<br>      project_id = string<br>    })<br>    environment   = string<br>    labels        = map(string)<br>    is_production = bool<br>  })</pre> | n/a | yes |
-| <a name="input_master_instance_name"></a> [master\_instance\_name](#input\_master\_instance\_name) | The name of the master instance to create a read-replica for. | `string` | n/a | yes |
+| <a name="input_master_instance"></a> [master\_instance](#input\_master\_instance) | The master instance to create a read-replica for. Must be a 'google\_sql\_database\_instance' from either the master resource or data. | `any` | n/a | yes |
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | Whether to enable high availability with automatic failover to another read-replica. 'REGIONAL' for HA, 'ZONAL' for single zone. | `string` | `null` | no |
 | <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | Override default CloudSQL configuration by specifying database-flags. | <pre>map(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `{}` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `bool` | `null` | no |

--- a/modules/postgresql-replica/README.md
+++ b/modules/postgresql-replica/README.md
@@ -35,8 +35,6 @@ No modules.
 | <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | Override default CloudSQL configuration by specifying database-flags. | <pre>map(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `{}` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `bool` | `null` | no |
 | <a name="input_machine_size_override"></a> [machine\_size\_override](#input\_machine\_size\_override) | By default, machine\_size will be the same as the master. Set this variable to override. Keep in mind that replica must have equal or higher machine\_size. See README.md for examples. | `map` | `null` | no |
-| <a name="input_query_insights_config"></a> [query\_insights\_config](#input\_query\_insights\_config) | Advanced config for Query Insights. | <pre>object({<br>    query_string_length     = number<br>    record_application_tags = bool<br>    record_client_address   = bool<br>  })</pre> | <pre>{<br>  "query_string_length": 1024,<br>  "record_application_tags": false,<br>  "record_client_address": false<br>}</pre> | no |
-| <a name="input_query_insights_enabled"></a> [query\_insights\_enabled](#input\_query\_insights\_enabled) | Whether to enable query insights (7 day retention). | `bool` | `false` | no |
 | <a name="input_replica_number"></a> [replica\_number](#input\_replica\_number) | The replica-number of the instance in the case of many. Starts at 1, ends at 999. Will be padded with leading zeros. Used as suffix for the instance-name | `number` | `1` | no |
 
 ## Outputs

--- a/modules/postgresql-replica/README.md
+++ b/modules/postgresql-replica/README.md
@@ -7,7 +7,6 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >=4.26.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.3 |
 
 ## Providers
 

--- a/modules/postgresql-replica/README.md
+++ b/modules/postgresql-replica/README.md
@@ -14,8 +14,6 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >=4.26.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0.3 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -25,54 +23,27 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_sql_database.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
-| [google_sql_database_instance.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
-| [google_sql_user.additional_users](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
-| [google_sql_user.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
-| [kubernetes_config_map.main_psql_connection](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
-| [kubernetes_secret.additional_database_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
-| [kubernetes_secret.main_database_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
-| [random_integer.additional_users_password_length](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
-| [random_integer.password_length](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
-| [random_password.additional_users_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [random_password.password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [google_sql_database_instance.replica](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
+| [google_sql_database_instance.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/sql_database_instance) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_databases"></a> [databases](#input\_databases) | Names of databases to create. | `list(string)` | n/a | yes |
 | <a name="input_init"></a> [init](#input\_init) | Entur init module output. https://github.com/entur/terraform-google-init. Used to determine application name, application project, labels, and resource names. | <pre>object({<br>    app = object({<br>      id         = string<br>      name       = string<br>      owner      = string<br>      project_id = string<br>    })<br>    environment   = string<br>    labels        = map(string)<br>    is_production = bool<br>  })</pre> | n/a | yes |
-| <a name="input_additional_users"></a> [additional\_users](#input\_additional\_users) | A list of user-names in addition to the main user that should be created. | <pre>map(object({<br>    username                 = string<br>    create_kubernetes_secret = bool<br>  }))</pre> | `{}` | no |
-| <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | Whether to enable high availability with automatic failover over multiple zones ('REGIONAL') vs. single zone ('ZONAL'). | `string` | `null` | no |
-| <a name="input_backup_start_time"></a> [backup\_start\_time](#input\_backup\_start\_time) | Start time in UTC for daily backup job in the format HH:MM. This is the start time of a 4 hour time window. | `string` | `"00:00"` | no |
-| <a name="input_create_kubernetes_resources"></a> [create\_kubernetes\_resources](#input\_create\_kubernetes\_resources) | Optionally disables creating k8s resources -psql-connection and -psql-credentials. Can be used to avoic overwriting existing resources on database creation. | `bool` | `true` | no |
+| <a name="input_master_instance_name"></a> [master\_instance\_name](#input\_master\_instance\_name) | The name of the master instance to create a read-replica for. | `string` | n/a | yes |
+| <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | Whether to enable high availability with automatic failover to another read-replica. 'REGIONAL' for HA, 'ZONAL' for single zone. | `string` | `null` | no |
 | <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | Override default CloudSQL configuration by specifying database-flags. | <pre>map(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `{}` | no |
-| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The PostgreSQL version (see https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version). | `string` | `"POSTGRES_14"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `bool` | `null` | no |
-| <a name="input_disable_offsite_backup"></a> [disable\_offsite\_backup](#input\_disable\_offsite\_backup) | Disable offsite backup for this instance. Offsite backup is only applied to production environments. | `bool` | `false` | no |
-| <a name="input_disk_autoresize"></a> [disk\_autoresize](#input\_disk\_autoresize) | Whether to enable auto-resizing of the storage disk. | `bool` | `true` | no |
-| <a name="input_disk_autoresize_limit"></a> [disk\_autoresize\_limit](#input\_disk\_autoresize\_limit) | The maximum size an auto-resized disk can reach. Default is 500 for production, 50 for non-production. | `number` | `null` | no |
-| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | The storage disk size of the instance. Default is 10 (GB). Only takes effect if disk\_autoresize is set to 'false'. | `number` | `10` | no |
-| <a name="input_enable_backup"></a> [enable\_backup](#input\_enable\_backup) | Whether to enable daily backup of databases. | `bool` | `true` | no |
-| <a name="input_generation"></a> [generation](#input\_generation) | The generation (aka serial no.) of the instance. Starts at 1, ends at 999. Will be padded with leading zeros. | `number` | `1` | no |
-| <a name="input_machine_size"></a> [machine\_size](#input\_machine\_size) | Map of the database instance CPU count (cpu) and memory sizes in MB (memory). Optionally, set a tier override (tier). See README.md for examples. | `map` | `null` | no |
-| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The day of the week (1-7), and hour of the day (0-24) in UTC to perform database instance maintenance. This is the start time of the one hour maintinance window. | <pre>object({<br>    day  = number<br>    hour = number<br>  })</pre> | <pre>{<br>  "day": 2,<br>  "hour": 0<br>}</pre> | no |
+| <a name="input_machine_size_override"></a> [machine\_size\_override](#input\_machine\_size\_override) | By default, machine\_size will be the same as the master. Set this variable to override. Keep in mind that replica must have equal or higher machine\_size. See README.md for examples. | `map` | `null` | no |
 | <a name="input_query_insights_config"></a> [query\_insights\_config](#input\_query\_insights\_config) | Advanced config for Query Insights. | <pre>object({<br>    query_string_length     = number<br>    record_application_tags = bool<br>    record_client_address   = bool<br>  })</pre> | <pre>{<br>  "query_string_length": 1024,<br>  "record_application_tags": false,<br>  "record_client_address": false<br>}</pre> | no |
 | <a name="input_query_insights_enabled"></a> [query\_insights\_enabled](#input\_query\_insights\_enabled) | Whether to enable query insights (7 day retention). | `bool` | `false` | no |
-| <a name="input_region"></a> [region](#input\_region) | The region the instance will sit in. | `string` | `"europe-west1"` | no |
-| <a name="input_retained_backups"></a> [retained\_backups](#input\_retained\_backups) | The number of backups to retain. Default is 30 for production, 7 for non-production. | `number` | `null` | no |
-| <a name="input_transaction_log_retention_days"></a> [transaction\_log\_retention\_days](#input\_transaction\_log\_retention\_days) | How long transaction logs are stored (1-7). | `number` | `7` | no |
-| <a name="input_user_name"></a> [user\_name](#input\_user\_name) | The username of the default application user. Defaults to the app ID. | `string` | `null` | no |
+| <a name="input_replica_number"></a> [replica\_number](#input\_replica\_number) | The replica-number of the instance in the case of many. Starts at 1, ends at 999. Will be padded with leading zeros. Used as suffix for the instance-name | `number` | `1` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_additional_users"></a> [additional\_users](#output\_additional\_users) | Map containing the username and password for any additional users. |
-| <a name="output_databases"></a> [databases](#output\_databases) | Databases created on this instance. |
 | <a name="output_init"></a> [init](#output\_init) | The output of the consumed init module. |
 | <a name="output_instance"></a> [instance](#output\_instance) | The database instance output, as described in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance. |
-| <a name="output_kubernetes_namespace"></a> [kubernetes\_namespace](#output\_kubernetes\_namespace) | Name of the Kubernetes namespace where config maps and secrets are deployed. |
-| <a name="output_user"></a> [user](#output\_user) | Map containing the username and password of the default application user. |
 <!-- END_TF_DOCS -->

--- a/modules/postgresql-replica/main.tf
+++ b/modules/postgresql-replica/main.tf
@@ -1,0 +1,53 @@
+locals {
+  deletion_protection = var.deletion_protection != null ? var.deletion_protection : var.init.is_production ? true : false
+  machine_size        = var.machine_size_override != null ? try(var.machine_size_override.tier, "db-custom-${var.machine_size_override.cpu}-${var.machine_size_override.memory}") : data.google_sql_database_instance.main.settings[0].tier
+  labels              = merge(var.init.labels, { label_backup_offsite = false })
+  replica_number      = format("%03d", var.replica_number)
+}
+
+data "google_sql_database_instance" "main" {
+  name    = var.master_instance_name
+  project = var.init.app.project_id
+}
+
+# See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
+resource "google_sql_database_instance" "replica" {
+  name             = "${data.google_sql_database_instance.main.name}-repl-${local.replica_number}"
+  project          = var.init.app.project_id
+  region           = data.google_sql_database_instance.main.region
+  database_version = data.google_sql_database_instance.main.database_version
+
+  master_instance_name = data.google_sql_database_instance.main.name
+  replica_configuration {
+    failover_target = false
+  }
+
+  settings {
+    user_labels           = local.labels
+    availability_type     = var.availability_type
+    disk_size             = null # must be null if disk_autoresize is true to avoid instance recreation when the disk expands
+    disk_autoresize       = true
+    disk_autoresize_limit = 0 # no-limit for read-replicas, limit should be controlled by master
+    tier                  = local.machine_size
+    ip_configuration {
+      require_ssl = true
+    }
+    # maintenance_window not set for read-replicas
+    insights_config {
+      query_insights_enabled  = var.query_insights_enabled
+      query_string_length     = var.query_insights_config.query_string_length
+      record_client_address   = var.query_insights_config.record_client_address
+      record_application_tags = var.query_insights_config.record_application_tags
+    }
+    dynamic "database_flags" {
+      for_each = var.database_flags
+      content {
+        name  = database_flags.value.name
+        value = database_flags.value.value
+      }
+    }
+  }
+
+  deletion_protection = local.deletion_protection
+}
+

--- a/modules/postgresql-replica/main.tf
+++ b/modules/postgresql-replica/main.tf
@@ -1,8 +1,7 @@
 locals {
-  deletion_protection = var.deletion_protection != null ? var.deletion_protection : var.init.is_production ? true : false
-  machine_size        = var.machine_size_override != null ? try(var.machine_size_override.tier, "db-custom-${var.machine_size_override.cpu}-${var.machine_size_override.memory}") : var.master_instance.settings[0].tier
-  labels              = merge(var.master_instance.settings[0].user_labels, { label_backup_offsite = false })
-  replica_number      = format("%03d", var.replica_number)
+  machine_size   = var.machine_size_override != null ? try(var.machine_size_override.tier, "db-custom-${var.machine_size_override.cpu}-${var.machine_size_override.memory}") : var.master_instance.settings[0].tier
+  labels         = merge(var.master_instance.settings[0].user_labels, { label_backup_offsite = false })
+  replica_number = format("%03d", var.replica_number)
 }
 
 # See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
@@ -21,7 +20,7 @@ resource "google_sql_database_instance" "replica" {
   settings {
     user_labels                 = local.labels
     availability_type           = var.availability_type
-    deletion_protection_enabled = local.deletion_protection
+    deletion_protection_enabled = var.master_instance.settings[0].deletion_protection_enabled
     # disk_size properties is inherited from the master, adding to ignore_changes
     # maintenance_window not set for read-replicas, adding to ignore_changes
     tier = local.machine_size
@@ -43,7 +42,7 @@ resource "google_sql_database_instance" "replica" {
     }
   }
 
-  deletion_protection = local.deletion_protection
+  deletion_protection = var.master_instance.deletion_protection
 
   # Inspired by https://github.com/terraform-google-modules/terraform-google-sql-db/blob/master/modules/postgresql/read_replica.tf#L108
   lifecycle {

--- a/modules/postgresql-replica/main.tf
+++ b/modules/postgresql-replica/main.tf
@@ -22,7 +22,7 @@ resource "google_sql_database_instance" "replica" {
     availability_type           = var.availability_type
     deletion_protection_enabled = var.master_instance.settings[0].deletion_protection_enabled
     # disk_size properties is inherited from the master, adding to ignore_changes
-    # maintenance_window not set for read-replicas, adding to ignore_changes
+    # maintenance_window is inherited from the master, adding to ignore_changes
     tier = local.machine_size
     ip_configuration {
       require_ssl = var.master_instance.settings[0].ip_configuration[0].require_ssl

--- a/modules/postgresql-replica/main.tf
+++ b/modules/postgresql-replica/main.tf
@@ -1,7 +1,7 @@
 locals {
   deletion_protection = var.deletion_protection != null ? var.deletion_protection : var.init.is_production ? true : false
   machine_size        = var.machine_size_override != null ? try(var.machine_size_override.tier, "db-custom-${var.machine_size_override.cpu}-${var.machine_size_override.memory}") : data.google_sql_database_instance.main.settings[0].tier
-  labels              = merge(var.init.labels, { label_backup_offsite = false })
+  labels              = merge(data.google_sql_database_instance.main.settings[0].user_labels, { label_backup_offsite = false })
   replica_number      = format("%03d", var.replica_number)
 }
 
@@ -13,31 +13,33 @@ data "google_sql_database_instance" "main" {
 # See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
 resource "google_sql_database_instance" "replica" {
   name             = "${data.google_sql_database_instance.main.name}-repl-${local.replica_number}"
-  project          = var.init.app.project_id
+  project          = data.google_sql_database_instance.main.project
   region           = data.google_sql_database_instance.main.region
   database_version = data.google_sql_database_instance.main.database_version
 
+  # replica specific settings
   master_instance_name = data.google_sql_database_instance.main.name
   replica_configuration {
     failover_target = false
   }
 
   settings {
-    user_labels           = local.labels
-    availability_type     = var.availability_type
-    disk_size             = null # must be null if disk_autoresize is true to avoid instance recreation when the disk expands
-    disk_autoresize       = true
-    disk_autoresize_limit = 0 # no-limit for read-replicas, limit should be controlled by master
-    tier                  = local.machine_size
+    user_labels                 = local.labels
+    availability_type           = var.availability_type
+    deletion_protection_enabled = local.deletion_protection
+    disk_size                   = null # must be null if disk_autoresize is true to avoid instance recreation when the disk expands
+    disk_autoresize             = true
+    disk_autoresize_limit       = 0 # no-limit for read-replicas, limit should be controlled by master
+    tier                        = local.machine_size
     ip_configuration {
-      require_ssl = true
+      require_ssl = data.google_sql_database_instance.main.settings[0].ip_configuration[0].require_ssl
     }
     # maintenance_window not set for read-replicas
     insights_config {
-      query_insights_enabled  = var.query_insights_enabled
-      query_string_length     = var.query_insights_config.query_string_length
-      record_client_address   = var.query_insights_config.record_client_address
-      record_application_tags = var.query_insights_config.record_application_tags
+      query_insights_enabled  = data.google_sql_database_instance.main.settings[0].insights_config[0].query_insights_enabled
+      query_string_length     = data.google_sql_database_instance.main.settings[0].insights_config[0].query_string_length
+      record_client_address   = data.google_sql_database_instance.main.settings[0].insights_config[0].record_client_address
+      record_application_tags = data.google_sql_database_instance.main.settings[0].insights_config[0].record_application_tags
     }
     dynamic "database_flags" {
       for_each = var.database_flags

--- a/modules/postgresql-replica/main.tf
+++ b/modules/postgresql-replica/main.tf
@@ -1,6 +1,6 @@
 locals {
   machine_size   = var.machine_size_override != null ? try(var.machine_size_override.tier, "db-custom-${var.machine_size_override.cpu}-${var.machine_size_override.memory}") : var.master_instance.settings[0].tier
-  labels         = merge(var.master_instance.settings[0].user_labels, { label_backup_offsite = false })
+  labels         = merge(var.master_instance.settings[0].user_labels, { offsite_enabled = false })
   replica_number = format("%03d", var.replica_number)
 }
 

--- a/modules/postgresql-replica/main.tf
+++ b/modules/postgresql-replica/main.tf
@@ -1,24 +1,19 @@
 locals {
   deletion_protection = var.deletion_protection != null ? var.deletion_protection : var.init.is_production ? true : false
-  machine_size        = var.machine_size_override != null ? try(var.machine_size_override.tier, "db-custom-${var.machine_size_override.cpu}-${var.machine_size_override.memory}") : data.google_sql_database_instance.main.settings[0].tier
-  labels              = merge(data.google_sql_database_instance.main.settings[0].user_labels, { label_backup_offsite = false })
+  machine_size        = var.machine_size_override != null ? try(var.machine_size_override.tier, "db-custom-${var.machine_size_override.cpu}-${var.machine_size_override.memory}") : var.master_instance.settings[0].tier
+  labels              = merge(var.master_instance.settings[0].user_labels, { label_backup_offsite = false })
   replica_number      = format("%03d", var.replica_number)
-}
-
-data "google_sql_database_instance" "main" {
-  name    = var.master_instance_name
-  project = var.init.app.project_id
 }
 
 # See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
 resource "google_sql_database_instance" "replica" {
-  name             = "${data.google_sql_database_instance.main.name}-repl-${local.replica_number}"
-  project          = data.google_sql_database_instance.main.project
-  region           = data.google_sql_database_instance.main.region
-  database_version = data.google_sql_database_instance.main.database_version
+  name             = "${var.master_instance.name}-repl-${local.replica_number}"
+  project          = var.master_instance.project
+  region           = var.master_instance.region
+  database_version = var.master_instance.database_version
 
   # replica specific settings
-  master_instance_name = data.google_sql_database_instance.main.name
+  master_instance_name = var.master_instance.name
   replica_configuration {
     failover_target = false
   }
@@ -27,19 +22,17 @@ resource "google_sql_database_instance" "replica" {
     user_labels                 = local.labels
     availability_type           = var.availability_type
     deletion_protection_enabled = local.deletion_protection
-    disk_size                   = null # must be null if disk_autoresize is true to avoid instance recreation when the disk expands
-    disk_autoresize             = true
-    disk_autoresize_limit       = 0 # no-limit for read-replicas, limit should be controlled by master
-    tier                        = local.machine_size
+    # disk_size properties is inherited from the master, adding to ignore_changes
+    # maintenance_window not set for read-replicas, adding to ignore_changes
+    tier = local.machine_size
     ip_configuration {
-      require_ssl = data.google_sql_database_instance.main.settings[0].ip_configuration[0].require_ssl
+      require_ssl = var.master_instance.settings[0].ip_configuration[0].require_ssl
     }
-    # maintenance_window not set for read-replicas
     insights_config {
-      query_insights_enabled  = data.google_sql_database_instance.main.settings[0].insights_config[0].query_insights_enabled
-      query_string_length     = data.google_sql_database_instance.main.settings[0].insights_config[0].query_string_length
-      record_client_address   = data.google_sql_database_instance.main.settings[0].insights_config[0].record_client_address
-      record_application_tags = data.google_sql_database_instance.main.settings[0].insights_config[0].record_application_tags
+      query_insights_enabled  = var.master_instance.settings[0].insights_config[0].query_insights_enabled
+      query_string_length     = var.master_instance.settings[0].insights_config[0].query_string_length
+      record_client_address   = var.master_instance.settings[0].insights_config[0].record_client_address
+      record_application_tags = var.master_instance.settings[0].insights_config[0].record_application_tags
     }
     dynamic "database_flags" {
       for_each = var.database_flags
@@ -51,5 +44,15 @@ resource "google_sql_database_instance" "replica" {
   }
 
   deletion_protection = local.deletion_protection
+
+  # Inspired by https://github.com/terraform-google-modules/terraform-google-sql-db/blob/master/modules/postgresql/read_replica.tf#L108
+  lifecycle {
+    ignore_changes = [
+      settings[0].disk_size,
+      settings[0].disk_autoresize,
+      settings[0].disk_autoresize_limit,
+      settings[0].maintenance_window,
+    ]
+  }
 }
 

--- a/modules/postgresql-replica/outputs.tf
+++ b/modules/postgresql-replica/outputs.tf
@@ -1,0 +1,9 @@
+output "init" {
+  description = "The output of the consumed init module."
+  value       = var.init
+}
+
+output "instance" {
+  description = "The database instance output, as described in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance."
+  value       = google_sql_database_instance.replica
+}

--- a/modules/postgresql-replica/variables.tf
+++ b/modules/postgresql-replica/variables.tf
@@ -69,26 +69,6 @@ variable "availability_type" {
   default     = null
 }
 
-variable "query_insights_enabled" {
-  description = "Whether to enable query insights (7 day retention)."
-  type        = bool
-  default     = false // Default false for non-breaking change
-}
-
-variable "query_insights_config" {
-  description = "Advanced config for Query Insights."
-  type = object({
-    query_string_length     = number
-    record_application_tags = bool
-    record_client_address   = bool
-  })
-  default = {
-    query_string_length     = 1024
-    record_application_tags = false
-    record_client_address   = false
-  }
-}
-
 variable "database_flags" {
   description = "Override default CloudSQL configuration by specifying database-flags."
   type = map(object({

--- a/modules/postgresql-replica/variables.tf
+++ b/modules/postgresql-replica/variables.tf
@@ -57,12 +57,6 @@ variable "replica_number" {
   }
 }
 
-variable "deletion_protection" {
-  description = "Whether or not to allow Terraform to destroy the instance."
-  type        = bool
-  default     = null
-}
-
 variable "availability_type" {
   description = "Whether to enable high availability with automatic failover to another read-replica. 'REGIONAL' for HA, 'ZONAL' for single zone."
   type        = string

--- a/modules/postgresql-replica/variables.tf
+++ b/modules/postgresql-replica/variables.tf
@@ -1,0 +1,99 @@
+variable "init" {
+  description = "Entur init module output. https://github.com/entur/terraform-google-init. Used to determine application name, application project, labels, and resource names."
+  type = object({
+    app = object({
+      id         = string
+      name       = string
+      owner      = string
+      project_id = string
+    })
+    environment   = string
+    labels        = map(string)
+    is_production = bool
+  })
+}
+
+variable "master_instance_name" {
+  type        = string
+  description = "The name of the master instance to create a read-replica for."
+}
+
+variable "machine_size_override" {
+  description = "By default, machine_size will be the same as the master. Set this variable to override. Keep in mind that replica must have equal or higher machine_size. See README.md for examples."
+  # type = object({
+  #   tier   = optional(string) # Optional attributes not supported until Terraform 1.3
+  #   cpu    = number
+  #   memory = number
+  # })
+  type = map
+  #default = {
+  #tier   = "db-f1-micro"
+  #cpu    = 1
+  #memory = 3840
+  #}
+  default = null
+  validation {
+    condition     = var.machine_size_override != null ? try(var.machine_size_override.cpu, 1) >= 1 && try(var.machine_size_override.cpu, 1) <= 96 : true
+    error_message = "CPU must be a whole number between 1 and 96."
+  }
+  validation {
+    condition     = var.machine_size_override != null ? try(var.machine_size_override.memory, 256) % 256 == 0 && try(var.machine_size_override.memory, 3840) >= 3840 && try(var.machine_size_override.memory, 3840) <= 13312 : true
+    error_message = "Memory must be divisable by 256, and between 3840 and 13312."
+  }
+  validation {
+    condition     = var.machine_size_override != null ? (try(var.machine_size_override.tier, null) != null) && (try(var.machine_size_override.cpu, null) == null || try(var.machine_size_override.memory, null) == null) || (try(var.machine_size_override.tier, null) == null) && (try(var.machine_size_override.cpu, null) != null && try(var.machine_size_override.memory, null) != null) : true
+    error_message = "Either supply desired resource limits for cpu and memory (recommended), or specify a tier."
+  }
+}
+
+variable "replica_number" {
+  description = "The replica-number of the instance in the case of many. Starts at 1, ends at 999. Will be padded with leading zeros. Used as suffix for the instance-name"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.replica_number < 1000 && var.replica_number > 0
+    error_message = "Replica-number must be between [1,999]."
+  }
+}
+
+variable "deletion_protection" {
+  description = "Whether or not to allow Terraform to destroy the instance."
+  type        = bool
+  default     = null
+}
+
+variable "availability_type" {
+  description = "Whether to enable high availability with automatic failover to another read-replica. 'REGIONAL' for HA, 'ZONAL' for single zone."
+  type        = string
+  default     = null
+}
+
+variable "query_insights_enabled" {
+  description = "Whether to enable query insights (7 day retention)."
+  type        = bool
+  default     = false // Default false for non-breaking change
+}
+
+variable "query_insights_config" {
+  description = "Advanced config for Query Insights."
+  type = object({
+    query_string_length     = number
+    record_application_tags = bool
+    record_client_address   = bool
+  })
+  default = {
+    query_string_length     = 1024
+    record_application_tags = false
+    record_client_address   = false
+  }
+}
+
+variable "database_flags" {
+  description = "Override default CloudSQL configuration by specifying database-flags."
+  type = map(object({
+    name  = string
+    value = string
+  }))
+  default = {}
+}

--- a/modules/postgresql-replica/variables.tf
+++ b/modules/postgresql-replica/variables.tf
@@ -14,7 +14,7 @@ variable "init" {
 }
 
 variable "master_instance" {
-  type        = any # TODO: what can we do here?
+  type        = any # can we do any more advanced typing here?
   description = "The master instance to create a read-replica for. Must be a 'google_sql_database_instance' from either the master resource or data."
 }
 

--- a/modules/postgresql-replica/variables.tf
+++ b/modules/postgresql-replica/variables.tf
@@ -13,9 +13,9 @@ variable "init" {
   })
 }
 
-variable "master_instance_name" {
-  type        = string
-  description = "The name of the master instance to create a read-replica for."
+variable "master_instance" {
+  type        = any # TODO: what can we do here?
+  description = "The master instance to create a read-replica for. Must be a 'google_sql_database_instance' from either the master resource or data."
 }
 
 variable "machine_size_override" {

--- a/modules/postgresql-replica/versions.tf
+++ b/modules/postgresql-replica/versions.tf
@@ -1,9 +1,5 @@
 terraform {
   required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.0.3"
-    }
     google = {
       source  = "hashicorp/google"
       version = ">=4.26.0"

--- a/modules/postgresql-replica/versions.tf
+++ b/modules/postgresql-replica/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.3"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = ">=4.26.0"
+    }
+  }
+  required_version = ">=0.13.2"
+}

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -10,7 +10,7 @@ locals {
   deletion_protection         = var.deletion_protection != null ? var.deletion_protection : var.init.is_production ? true : false
   availability_type           = var.availability_type != null ? var.availability_type : var.init.is_production ? "REGIONAL" : "ZONAL"
   machine_size                = var.machine_size != null ? try(var.machine_size.tier, "db-custom-${var.machine_size.cpu}-${var.machine_size.memory}") : var.init.is_production ? local.default_tiers.prod : local.default_tiers.non-prod
-  offsite_backup_label        = var.disable_offsite_backup == true && var.init.is_production ? { label_backup_offsite = false } : {} # Add the label for opt-out of offsite backup in prod environments when disable_offsite_backup is true
+  offsite_backup_label        = var.disable_offsite_backup == true && var.init.is_production ? { offsite_enabled = false } : {} # Add the label for opt-out of offsite backup in prod environments when disable_offsite_backup is true
   labels                      = merge(var.init.labels, local.offsite_backup_label)
   generation                  = format("%03d", var.generation)
   disk_autoresize_limit       = var.disk_autoresize_limit != null ? var.disk_autoresize_limit : var.init.is_production ? 500 : 50


### PR DESCRIPTION
Creates a new module postgresql-replica to support managing read-replicas via terraform. 

Not incorporated in `postgresql` module due to too many spesialcases.

Tested in `migexa`:

```terraform
module "postgres" {
  source           = "github.com/entur/terraform-google-sql-db//modules/postgresql?ref=v1.2.0"
  init             = module.init
  generation       = 10
  database_version = "POSTGRES_14"
  databases        = ["migexa"]
  user_name        = "migexa"
  machine_size     = { tier = "db-custom-1-3840" }

  availability_type           = "ZONAL"
  query_insights_enabled      = true
  create_kubernetes_resources = false
}

module "postgres-replica-001" {
  source               = "/Users/gustav/projects/entur/terraform-google-sql-db//modules/postgresql-replica"
  init                 = module.init
  replica_number       = 1
  master_instance_name = module.postgres.instance.name
  availability_type    = "ZONAL"
}
```