### PR TITLE
fix: Add deletion-protection across apis

### DIFF
--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -26,12 +26,13 @@ resource "google_sql_database_instance" "main" {
   region           = var.region
 
   settings {
-    user_labels           = local.labels
-    availability_type     = local.availability_type
-    disk_size             = var.disk_autoresize ? null : var.disk_size # must be null if disk_autoresize is true to avoid instance recreation when the disk expands
-    disk_autoresize       = var.disk_autoresize
-    disk_autoresize_limit = local.disk_autoresize_limit
-    tier                  = local.machine_size
+    user_labels                 = local.labels
+    availability_type           = local.availability_type
+    deletion_protection_enabled = var.deletion_protection
+    disk_size                   = var.disk_autoresize ? null : var.disk_size # must be null if disk_autoresize is true to avoid instance recreation when the disk expands
+    disk_autoresize             = var.disk_autoresize
+    disk_autoresize_limit       = local.disk_autoresize_limit
+    tier                        = local.machine_size
     backup_configuration {
       enabled                        = var.enable_backup
       point_in_time_recovery_enabled = true

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -28,7 +28,7 @@ resource "google_sql_database_instance" "main" {
   settings {
     user_labels                 = local.labels
     availability_type           = local.availability_type
-    deletion_protection_enabled = var.deletion_protection
+    deletion_protection_enabled = local.deletion_protection
     disk_size                   = var.disk_autoresize ? null : var.disk_size # must be null if disk_autoresize is true to avoid instance recreation when the disk expands
     disk_autoresize             = var.disk_autoresize
     disk_autoresize_limit       = local.disk_autoresize_limit


### PR DESCRIPTION
Enable full deletion-protection. Existing protection is terraform-only.

CloudSQL feature:
https://cloud.google.com/sql/docs/release-notes#August_15_2022

Supported in provider since January 2023