### PR TITLE
feat: open up for modifying allowed networks

### DIFF
--- a/modules/postgresql-replica/variables.tf
+++ b/modules/postgresql-replica/variables.tf
@@ -25,7 +25,7 @@ variable "machine_size_override" {
   #   cpu    = number
   #   memory = number
   # })
-  type = map
+  type = map(any)
   #default = {
   #tier   = "db-f1-micro"
   #cpu    = 1

--- a/modules/postgresql-replica/variables.tf
+++ b/modules/postgresql-replica/variables.tf
@@ -25,7 +25,7 @@ variable "machine_size_override" {
   #   cpu    = number
   #   memory = number
   # })
-  type = map(any)
+  type = map
   #default = {
   #tier   = "db-f1-micro"
   #cpu    = 1

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -16,7 +16,6 @@ locals {
   disk_autoresize_limit       = var.disk_autoresize_limit != null ? var.disk_autoresize_limit : var.init.is_production ? 500 : 50
   additional_users            = { for key, value in var.additional_users : key => value if value.username != local.user_name }
   additional_user_credentials = ! var.create_kubernetes_resources ? {} : { for key, value in local.additional_users : key => value if value.create_kubernetes_secret }
-  authorized_networks         = length(var.authorized_networks) != 0 ? var.authorized_networks : []
 }
 
 # See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
@@ -45,11 +44,11 @@ resource "google_sql_database_instance" "main" {
     ip_configuration {
       require_ssl = true
       dynamic "authorized_networks" {
-        for_each = local.authorized_networks
+        for_each = var.authorized_networks
         iterator = authnet
         content {
-          name = "IP or Range allowed: ${authnet.key}"
-          value= authnet.value
+          name  = authnet.value.name
+          value = authnet.value.value
         }
 
       }

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -15,7 +15,7 @@ locals {
   generation                  = format("%03d", var.generation)
   disk_autoresize_limit       = var.disk_autoresize_limit != null ? var.disk_autoresize_limit : var.init.is_production ? 500 : 50
   additional_users            = { for key, value in var.additional_users : key => value if value.username != local.user_name }
-  additional_user_credentials = ! var.create_kubernetes_resources ? {} : { for key, value in local.additional_users : key => value if value.create_kubernetes_secret }
+  additional_user_credentials = !var.create_kubernetes_resources ? {} : { for key, value in local.additional_users : key => value if value.create_kubernetes_secret }
 }
 
 # See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -16,6 +16,7 @@ locals {
   disk_autoresize_limit       = var.disk_autoresize_limit != null ? var.disk_autoresize_limit : var.init.is_production ? 500 : 50
   additional_users            = { for key, value in var.additional_users : key => value if value.username != local.user_name }
   additional_user_credentials = ! var.create_kubernetes_resources ? {} : { for key, value in local.additional_users : key => value if value.create_kubernetes_secret }
+  authorized_networks         = var.authorized_networks ? var.authorized_networks : []
 }
 
 # See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
@@ -43,6 +44,15 @@ resource "google_sql_database_instance" "main" {
     }
     ip_configuration {
       require_ssl = true
+      dynamic "authorized_networks" {
+        for_each = local.authorized_networks
+        iterator = authnet
+        content {
+          name = "IP or Range allowed: ${authnet.key}"
+          value= authnet.value
+        }
+
+      }
     }
     maintenance_window {
       day          = var.maintenance_window.day

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -16,7 +16,7 @@ locals {
   disk_autoresize_limit       = var.disk_autoresize_limit != null ? var.disk_autoresize_limit : var.init.is_production ? 500 : 50
   additional_users            = { for key, value in var.additional_users : key => value if value.username != local.user_name }
   additional_user_credentials = ! var.create_kubernetes_resources ? {} : { for key, value in local.additional_users : key => value if value.create_kubernetes_secret }
-  authorized_networks         = var.authorized_networks.count != 0 ? var.authorized_networks : []
+  authorized_networks         = length(var.authorized_networks) != 0 ? var.authorized_networks : []
 }
 
 # See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -16,7 +16,7 @@ locals {
   disk_autoresize_limit       = var.disk_autoresize_limit != null ? var.disk_autoresize_limit : var.init.is_production ? 500 : 50
   additional_users            = { for key, value in var.additional_users : key => value if value.username != local.user_name }
   additional_user_credentials = ! var.create_kubernetes_resources ? {} : { for key, value in local.additional_users : key => value if value.create_kubernetes_secret }
-  authorized_networks         = var.authorized_networks ? var.authorized_networks : []
+  authorized_networks         = var.authorized_networks.count != 0 ? var.authorized_networks : []
 }
 
 # See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -26,7 +26,7 @@ variable "machine_size" {
   #   cpu    = number
   #   memory = number
   # })
-  type = map(any)
+  type = map
   #default = {
   #tier   = "db-f1-micro"
   #cpu    = 1

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -218,10 +218,10 @@ variable "create_kubernetes_resources" {
 }
 
 variable "authorized_networks" {
-  description = "Values for authorized_networks, simple strings with IPs or CIDRs. Ex: 35.90.103.132/30 or 35.90.103.132"
-  type        = map(object({
+  description = "Values for authorized_networks, list of objects with name and simple strings of IPs or CIDRs. Ex: {name: supermachine, value: 35.90.103.132/30} or {name: rogersmachine, value: 35.90.103.132}"
+  type        = list(object({
     value = string
     name = string
   }))
-  default     = {}
+  default     = []
 }

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -216,3 +216,9 @@ variable "create_kubernetes_resources" {
   type        = bool
   default     = true
 }
+
+variable "authorized_networks" {
+  description = "Values for authorized_networks, simple strings with IPs or CIDRs. Ex: 35.90.103.132/30 or 35.90.103.132"
+  type        = list(string)
+  default     = []
+}

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -219,6 +219,9 @@ variable "create_kubernetes_resources" {
 
 variable "authorized_networks" {
   description = "Values for authorized_networks, simple strings with IPs or CIDRs. Ex: 35.90.103.132/30 or 35.90.103.132"
-  type        = list(string)
-  default     = []
+  type        = map(object({
+    value = string
+    name = string
+  }))
+  default     = {}
 }

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -26,7 +26,7 @@ variable "machine_size" {
   #   cpu    = number
   #   memory = number
   # })
-  type = map
+  type = map(any)
   #default = {
   #tier   = "db-f1-micro"
   #cpu    = 1
@@ -219,9 +219,9 @@ variable "create_kubernetes_resources" {
 
 variable "authorized_networks" {
   description = "Values for authorized_networks, list of objects with name and simple strings of IPs or CIDRs. Ex: {name: supermachine, value: 35.90.103.132/30} or {name: rogersmachine, value: 35.90.103.132}"
-  type        = list(object({
+  type = list(object({
     value = string
-    name = string
+    name  = string
   }))
-  default     = []
+  default = []
 }


### PR DESCRIPTION
This is a need that is coming from using external tools to connect to the database.

Team Personalisering is testing out retool self hosted - https://retool.com/
Under: https://retool.entur.io/

And now to be able to add a database as a resource we need to allow certain networks to connect. The module allows public IP, but not to specify what network that can access.

This is needed as cloud proxy setup does not work: https://community.retool.com/t/using-cloud-sql-proxy-from-google-activly-both-on-self-host-and-on-resources/23004/3. If this starts to work, I can drop allowed networks.