### PR TITLE
fix: Replace references to deprecated property 'require_ssl' with 'ssl_mode' for postgres-replica module

### DIFF
--- a/examples/postgres-replica/main.tf
+++ b/examples/postgres-replica/main.tf
@@ -1,0 +1,54 @@
+locals {
+  read_replica_ip_configuration = {    
+    ssl_mode = "ENCRYPTED_ONLY"
+  }
+}
+
+resource "random_integer" "random_database_generation" {
+  # This resource block is used to randomize instance names for testing;
+  # do not include this in a live configuration.
+  min = 1
+  max = 999
+}
+
+module "init" {
+  # This is an example only; if you're adding this block to a live configuration,
+  # make sure to use the latest release of the init module, found here:
+  # https://github.com/entur/terraform-google-init/releases
+  source      = "github.com/entur/terraform-google-init//modules/init?ref=v1.0.0"
+  app_id      = "tfmodules"
+  environment = "dev"
+}
+
+module "postgresql" {
+  # This is for local reference only; if you're using this module as a published
+  # module from GitHub, the 'source' parameter must refer to it's public location.
+  # See README.md for instructions.
+  # source     = "github.com/entur/terraform-google-sql-db//modules/postgresql?ref=vVERSION"
+  source     = "../../modules/postgresql"
+  init       = module.init
+  generation = random_integer.random_database_generation.result
+  availability_type = "REGIONAL"
+  ip_configuration  = local.read_replica_ip_configuration
+  databases  = ["database-1", "database-2"]
+  machine_size = {
+    cpu    = 1
+    memory = 3840
+  }
+  additional_users = {
+    user1 = { username = "user1", create_kubernetes_secret = false },
+    user2 = { username = "user2", create_kubernetes_secret = false }
+  }
+}
+
+
+module "postgres-replica" {  
+  source = "github.com/entur/terraform-google-sql-db//modules/postgresql-replica?ref=v1.7.2"
+  init   = module.init
+
+  replica_number  = 1
+  master_instance = module.postgres[0].instance
+  ip_configuration  = local.read_replica_ip_configuration
+
+  availability_type = "ZONAL"
+}

--- a/examples/postgres-replica/outputs.tf
+++ b/examples/postgres-replica/outputs.tf
@@ -1,0 +1,15 @@
+output "instance_name" {
+  description = "The database instance name."
+  value       = module.postgresql.instance.name
+  sensitive   = true
+}
+
+output "project_id" {
+  description = "Project ID"
+  value       = module.init.app.project_id
+}
+
+output "app_id" {
+  description = "Application ID"
+  value       = module.init.app.id
+}

--- a/examples/postgres-replica/variables.tf
+++ b/examples/postgres-replica/variables.tf
@@ -1,0 +1,20 @@
+variable "init" {
+  default = {
+    app = {
+      id         = "tfmodules"
+      name       = "tf-mod-google-postgresql"
+      owner      = "team-plattform"
+      project_id = "ent-tfmodules-dev"
+    }
+    environment = "dev"
+    labels = {
+      app    = "tf-mod-google-postgresql"
+      app_id = "tfmodules"
+      env    = "dev"
+      team   = "team-plattform"
+      owner  = "team-plattform"
+    }
+    is_production = false
+  }
+}
+

--- a/modules/postgresql-replica/main.tf
+++ b/modules/postgresql-replica/main.tf
@@ -25,7 +25,7 @@ resource "google_sql_database_instance" "replica" {
     # maintenance_window is inherited from the master, adding to ignore_changes
     tier = local.machine_size
     ip_configuration {
-      ssl_mode = var.master_instance.settings[0].ip_configuration[0].require_ssl ? "ENCRYPTED_ONLY" : "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+      ssl_mode = var.master_instance.settings[0].ip_configuration[0].ssl_mode ? "ENCRYPTED_ONLY" : "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     }
     insights_config {
       query_insights_enabled  = var.master_instance.settings[0].insights_config[0].query_insights_enabled

--- a/test/integration/postgresql_replica/postgresql_replica_test.go
+++ b/test/integration/postgresql_replica/postgresql_replica_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+package postgresql_replica
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+const exampleDir = "../../../examples/postgres-replica"
+
+func TestPostgreSqlReplicaModule(t *testing.T) {
+	cloudSqlT := tft.NewTFBlueprintTest(t,
+		tft.WithTFDir(exampleDir),
+	)
+
+	pSql.DefineVerify(func(assert *assert.Assertions) {
+		// pSql.DefaultVerify(assert)
+
+		instaceNames := []string{pSql.GetStringOutput("name")}
+		projectId := pSql.GetStringOutput("project_id")
+		op := gcloud.Runf(t, "sql instances describe %s --project %s", instaceNames[0], projectId)
+
+		assert.Equal(1, len(op.Get("replicaNames").Array()), "Expected 1 replicas")
+		
+		instaceNames = append(instaceNames, utils.GetResultStrSlice(op.Get("replicaNames").Array())...)
+
+		for _, instance := range instaceNames {
+			op = gcloud.Runf(t, "sql instances describe %s --project %s", instance, projectId)
+
+			// assert general database settings
+			assert.Equal("POSTGRES_14", db.Get("databaseVersion").String(), "Expected POSTGRES_14 databaseVersion")
+			assert.Equal("RUNNABLE", db.Get("state").String(), "Expected RUNNABLE state")
+			assert.Equal("europe-west1", db.Get("region").String(), "Expected europe-west1 region")
+			assert.Equal("sql#maintenanceWindow", db.Get("settings.maintenanceWindow.kind").String(), "Expected sql#maintenanceWindow maintenanceWindow.kind")
+			assert.Equal(int64(2), db.Get("settings.maintenanceWindow.day").Int(), "Expected 2 maintenanceWindow.day")
+			assert.Equal(int64(0), db.Get("settings.maintenanceWindow.hour").Int(), "Expected 0 maintenanceWindow.hour")
+
+			// master specific validation
+			if instance == pSql.GetStringOutput("name") {
+				// assert general database settings
+				assert.Equal("REGIONAL", op.Get("settings.availabilityType").String(), "Expected REGIONAL availabilityType")
+				assert.Equal(op.Get("settings.ipConfiguration.sslMode").String(), "ENCRYPTED_ONLY")
+
+				// replica specific validation
+			} else {
+				// assert general database settings
+				assert.Equal("ZONAL", op.Get("settings.availabilityType").String(), "Expected ZONAL availabilityType")
+				assert.Equal(op.Get("settings.ipConfiguration.sslMode").String(), "ENCRYPTED_ONLY")
+			}
+		}
+
+	})
+
+	pSql.Test()
+}


### PR DESCRIPTION
## TL;DR
Fixes #64 