### PR TITLE
fix: bump deps and minor chores

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @entur/terraform-module-reviewers
+*       @entur/team-plattform

--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ A PostgreSQL module that uses the [init module](https://github.com/entur/terrafo
 ## Getting started
 
 <!-- ci: x-release-please-start-version -->
+
 ### Example using the latest release
 
 ```terraform
 module "postgresql" {
-  source = "github.com/entur/terraform-google-sql-db//modules/postgresql?ref=v1.7.1"
+  source = "github.com/entur/terraform-google-sql-db//modules/postgresql?ref=v1.7.4"
   ...
 }
 ```
+
 <!-- ci: x-release-please-end -->
 
 See the `README.md` under each module's subfolder for a list of supported inputs and outputs. For examples showing how they're implemented, check the [examples](examples) subfolder.
@@ -35,10 +37,10 @@ Dependency automation tools such as Renovate Bot will be able to discover new re
 
 If a desired machine size and/or availability type is not explicitly set, defaults will be used:
 
-| Environment    | Type           | CPU  | Memory  | Highly available |
-|----------------|----------------|------|---------|------------------|
-| non-production | Shared vCPU    | <1   | 600 MB  | No               |
-| production     | Dedicated vCPU | 1    | 3840 MB | Yes              |
+| Environment    | Type           | CPU | Memory  | Highly available |
+| -------------- | -------------- | --- | ------- | ---------------- |
+| non-production | Shared vCPU    | <1  | 600 MB  | No               |
+| production     | Dedicated vCPU | 1   | 3840 MB | Yes              |
 
 ### Sizing
 
@@ -68,7 +70,10 @@ module "postgresql" {
 ### Integration Tests
 
 Run local integration tests in test/integration folder.
-*NB* Only Team-Plattform has rights to do this locally.
+
+> [!IMPORTANT]  
+> Only Team-Plattform has rights to do this locally.
+> Contributors can create a PR which will run the tests as well.
 
 Make sure you are connected to the dev kubernetes cluster in GKE (kub-ent-dev-001)
 

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -11,7 +11,7 @@ module "init" {
 
 # ci: x-release-please-start-version
 module "postgresql" {
-  source    = "github.com/entur/terraform-google-sql-db//modules/postgresql?ref=v1.7.1"
+  source    = "github.com/entur/terraform-google-sql-db//modules/postgresql?ref=v1.7.4"
   init      = module.init
   databases = ["my-database"]
 }

--- a/examples/minimal_replica/main.tf
+++ b/examples/minimal_replica/main.tf
@@ -11,7 +11,7 @@ module "init" {
 
 # ci: x-release-please-start-version
 module "postgresql" {
-  source            = "github.com/entur/terraform-google-sql-db//modules/postgresql?ref=v1.7.1"
+  source            = "github.com/entur/terraform-google-sql-db//modules/postgresql?ref=v1.7.4"
   init              = module.init
   availability_type = "REGIONAL"
   databases         = ["my-database"]
@@ -20,7 +20,7 @@ module "postgresql" {
 
 # ci: x-release-please-start-version
 module "postgres-replica" {
-  source          = "github.com/entur/terraform-google-sql-db//modules/postgresql-replica?ref=v1.7.1"
+  source          = "github.com/entur/terraform-google-sql-db//modules/postgresql-replica?ref=v1.7.4"
   init            = module.init
   master_instance = module.postgresql.instance
 }

--- a/modules/postgresql-replica/versions.tf
+++ b/modules/postgresql-replica/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">=4.26.0"
+      version = ">=5"
     }
   }
   required_version = ">=0.13.2"

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0.3"
+      version = ">=2.0.3"
     }
     google = {
       source  = "hashicorp/google"
-      version = ">=4.26.0"
+      version = ">=5"
     }
     random = {
       source  = "hashicorp/random"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
Remove Renovate

Bump [terraform-google-sql-db/modules/postgresql/versions.tf at main · entur/terraform-google-sql-db](https://github.com/entur/terraform-google-sql-db/blob/main/modules/postgresql/versions.tf#L9)  and [terraform-google-sql-db/modules/postgresql-replica/versions.tf at main · entur/terraform-google-sql-db](https://github.com/entur/terraform-google-sql-db/blob/main/modules/postgresql-replica/versions.tf#L5C6-L5C27) to  >=v5 (due to deprecation fixes)

Update README with info about tests on PR and local runs only for team platform.

Edit CODEOWNERS terraform-module-reviewers => team-plattform