### PR TITLE
feat: Enable iam_authentication by default

### DIFF
--- a/.github/workflows/pr-int-test-terraform.yml
+++ b/.github/workflows/pr-int-test-terraform.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "modules/postgresql/**"
+      - "modules/postgresql-replica/**"
       - "test/**"
     branches:
       - main

--- a/modules/postgresql-replica/README.md
+++ b/modules/postgresql-replica/README.md
@@ -1,5 +1,11 @@
 # Postgres Terraform Module #
 
+> **IAM database authentication is always enabled.** This module forces the
+> `cloudsql.iam_authentication` flag to `on`. Any `database_flags` entry
+> targeting `cloudsql.iam_authentication` is stripped and replaced (regardless
+> of its map key), so it cannot be disabled. Do not set this flag yourself;
+> leave it to the module.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/postgresql-replica/README.md
+++ b/modules/postgresql-replica/README.md
@@ -12,13 +12,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13.2 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >=5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >=5.12.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >=5 |
+| <a name="provider_google"></a> [google](#provider\_google) | >=5.12.0 |
 
 ## Modules
 

--- a/modules/postgresql-replica/main.tf
+++ b/modules/postgresql-replica/main.tf
@@ -2,7 +2,7 @@ locals {
   machine_size   = var.machine_size_override != null ? try(var.machine_size_override.tier, "db-custom-${var.machine_size_override.cpu}-${var.machine_size_override.memory}") : var.master_instance.settings[0].tier
   labels         = merge(var.master_instance.settings[0].user_labels, { offsite_enabled = false })
   replica_number = format("%03d", var.replica_number)
-  
+
   database_flags = merge(
     { for k, v in var.database_flags : k => v if v.name != "cloudsql.iam_authentication" },
     { iam_authentication = { name = "cloudsql.iam_authentication", value = "on" } },

--- a/modules/postgresql-replica/main.tf
+++ b/modules/postgresql-replica/main.tf
@@ -2,6 +2,11 @@ locals {
   machine_size   = var.machine_size_override != null ? try(var.machine_size_override.tier, "db-custom-${var.machine_size_override.cpu}-${var.machine_size_override.memory}") : var.master_instance.settings[0].tier
   labels         = merge(var.master_instance.settings[0].user_labels, { offsite_enabled = false })
   replica_number = format("%03d", var.replica_number)
+  
+  database_flags = merge(
+    { for k, v in var.database_flags : k => v if v.name != "cloudsql.iam_authentication" },
+    { iam_authentication = { name = "cloudsql.iam_authentication", value = "on" } },
+  )
 }
 
 # See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
@@ -35,7 +40,7 @@ resource "google_sql_database_instance" "replica" {
       record_application_tags = var.master_instance.settings[0].insights_config[0].record_application_tags
     }
     dynamic "database_flags" {
-      for_each = var.database_flags
+      for_each = local.database_flags
       content {
         name  = database_flags.value.name
         value = database_flags.value.value

--- a/modules/postgresql-replica/versions.tf
+++ b/modules/postgresql-replica/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">=5"
+      version = ">=5.12.0"
     }
   }
   required_version = ">=0.13.2"

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -17,7 +17,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13.2 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >=5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >=5.12.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >=3.6.2 |
 
@@ -25,7 +25,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >=5 |
+| <a name="provider_google"></a> [google](#provider\_google) | >=5.12.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >=3.6.2 |
 
@@ -44,6 +44,7 @@ No modules.
 | [google_sql_database.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
 | [google_sql_database_instance.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
 | [google_sql_user.additional_users](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
+| [google_sql_user.iam_groups](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
 | [google_sql_user.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
 | [kubernetes_config_map.main_psql_connection](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_secret.additional_database_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
@@ -76,6 +77,7 @@ No modules.
 | <a name="input_enable_backup"></a> [enable\_backup](#input\_enable\_backup) | Whether to enable daily backup of databases. | `bool` | `true` | no |
 | <a name="input_enable_private_network"></a> [enable\_private\_network](#input\_enable\_private\_network) | Whether to enable private network connectivity for the Cloud SQL instance. Immutable after it has been enabled. | `bool` | `false` | no |
 | <a name="input_generation"></a> [generation](#input\_generation) | The generation (aka serial no.) of the instance. Starts at 1, ends at 999. Will be padded with leading zeros. | `number` | `1` | no |
+| <a name="input_iam_groups"></a> [iam\_groups](#input\_iam\_groups) | IAM groups (by email) to register as CLOUD\_IAM\_GROUP database users on the instance. Members authenticate via IAM; project-IAM and in-database access are managed in GCP. Read replicas inherit these automatically. | `set(string)` | `[]` | no |
 | <a name="input_instance_edition"></a> [instance\_edition](#input\_instance\_edition) | Override the default instance edition (`ENTERPRISE` or `ENTERPRISE_PLUS`). | `string` | `"ENTERPRISE"` | no |
 | <a name="input_machine_size"></a> [machine\_size](#input\_machine\_size) | Map of the database instance CPU count (cpu) and memory sizes in MB (memory). Optionally, set a tier override (tier). See README.md for examples. | `map(any)` | `null` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The day of the week (1-7), and hour of the day (0-24) in UTC to perform database instance maintenance. This is the start time of the one hour maintinance window. | <pre>object({<br/>    day  = number<br/>    hour = number<br/>  })</pre> | <pre>{<br/>  "day": 2,<br/>  "hour": 0<br/>}</pre> | no |
@@ -95,6 +97,7 @@ No modules.
 |------|-------------|
 | <a name="output_additional_users"></a> [additional\_users](#output\_additional\_users) | Map containing the username and password for any additional users. |
 | <a name="output_databases"></a> [databases](#output\_databases) | Databases created on this instance. |
+| <a name="output_iam_group_users"></a> [iam\_group\_users](#output\_iam\_group\_users) | Names (emails) of the registered CLOUD\_IAM\_GROUP database users. |
 | <a name="output_init"></a> [init](#output\_init) | The output of the consumed init module. |
 | <a name="output_instance"></a> [instance](#output\_instance) | The database instance output, as described in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance. |
 | <a name="output_kubernetes_namespace"></a> [kubernetes\_namespace](#output\_kubernetes\_namespace) | Name of the Kubernetes namespace where config maps and secrets are deployed. |

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -1,5 +1,16 @@
 # Postgres Terraform Module #
 
+> **IAM database authentication is always enabled.** This module forces the
+> `cloudsql.iam_authentication` flag to `on`. Any `database_flags` entry
+> targeting `cloudsql.iam_authentication` is stripped and replaced (regardless
+> of its map key), so it cannot be disabled. Do not set this flag yourself;
+> leave it to the module.
+>
+> To grant an IAM group access, pass its email in `iam_groups`; the module
+> registers it as a `CLOUD_IAM_GROUP` database user. Project-IAM roles and
+> in-database privileges are handled in GCP, not by this module. Read replicas
+> inherit these users automatically.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -17,6 +17,11 @@ locals {
   additional_users               = { for key, value in var.additional_users : key => value if value.username != local.user_name }
   additional_user_credentials    = !var.create_kubernetes_resources ? {} : { for key, value in local.additional_users : key => value if value.create_kubernetes_secret }
   additional_sm_user_credentials = !var.add_additional_secret_manager_credentials ? {} : { for key, value in local.additional_users : key => value if var.add_additional_secret_manager_credentials }
+
+  database_flags = merge(
+    { for k, v in var.database_flags : k => v if v.name != "cloudsql.iam_authentication" },
+    { iam_authentication = { name = "cloudsql.iam_authentication", value = "on" } },
+  )
 }
 
 # See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
@@ -69,7 +74,7 @@ resource "google_sql_database_instance" "main" {
       record_application_tags = var.query_insights_config.record_application_tags
     }
     dynamic "database_flags" {
-      for_each = var.database_flags
+      for_each = local.database_flags
       content {
         name  = database_flags.value.name
         value = database_flags.value.value
@@ -157,6 +162,14 @@ resource "google_sql_user" "additional_users" {
   project  = var.init.app.project_id
   instance = google_sql_database_instance.main.name
   password = random_password.additional_users_password[each.key].result
+}
+
+resource "google_sql_user" "iam_groups" {
+  for_each = var.iam_groups
+  name     = each.value
+  project  = var.init.app.project_id
+  instance = google_sql_database_instance.main.name
+  type     = "CLOUD_IAM_GROUP"
 }
 
 resource "random_integer" "additional_users_password_length" {

--- a/modules/postgresql/outputs.tf
+++ b/modules/postgresql/outputs.tf
@@ -28,6 +28,11 @@ output "instance" {
   value       = google_sql_database_instance.main
 }
 
+output "iam_group_users" {
+  description = "Names (emails) of the registered CLOUD_IAM_GROUP database users."
+  value       = [for g in google_sql_user.iam_groups : g.name]
+}
+
 output "databases" {
   description = "Databases created on this instance."
   value       = var.databases

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -100,6 +100,12 @@ variable "additional_users" {
   }
 }
 
+variable "iam_groups" {
+  description = "IAM groups (by email) to register as CLOUD_IAM_GROUP database users on the instance. Members authenticate via IAM; project-IAM and in-database access are managed in GCP. Read replicas inherit these automatically."
+  type        = set(string)
+  default     = []
+}
+
 variable "retained_backups" {
   description = "The number of backups to retain. Default is 30 for production, 7 for non-production."
   type        = number

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = ">=5"
+      version = ">=5.12.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/test/fixtures/postgres-replica/main.tf
+++ b/test/fixtures/postgres-replica/main.tf
@@ -35,6 +35,8 @@ module "postgresql" {
     user1 = { username = "user1", create_kubernetes_secret = false },
     user2 = { username = "user2", create_kubernetes_secret = false }
   }
+
+  iam_groups = ["sg-dig-team-produkt@entur.no"]
 }
 
 

--- a/test/integration/postgresql_replica/postgresql_replica_test.go
+++ b/test/integration/postgresql_replica/postgresql_replica_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 const exampleDir = "../../fixtures/postgres-replica"
+const iamGroupEmail = "sg-dig-team-produkt@entur.no"
 
 func TestPostgreSqlReplicaModule(t *testing.T) {
 	cloudSqlT := tft.NewTFBlueprintTest(t,
@@ -35,13 +36,34 @@ func TestPostgreSqlReplicaModule(t *testing.T) {
 			// assert general database settings
 			assert.Equal("POSTGRES_14", op.Get("databaseVersion").String(), "Expected POSTGRES_14 databaseVersion")
 			assert.Equal("RUNNABLE", op.Get("state").String(), "Expected RUNNABLE state")
-			assert.Equal("europe-west1", op.Get("region").String(), "Expected europe-west1 region")		
+			assert.Equal("europe-west1", op.Get("region").String(), "Expected europe-west1 region")
+
+			// IAM database authentication must be forced on for every instance
+			// (master and replicas), regardless of caller-provided database_flags.
+			iamAuthEnabled := false
+			for _, flag := range op.Get("settings.databaseFlags").Array() {
+				if flag.Get("name").String() == "cloudsql.iam_authentication" && flag.Get("value").String() == "on" {
+					iamAuthEnabled = true
+					break
+				}
+			}
+			assert.True(iamAuthEnabled, "Expected cloudsql.iam_authentication=on on instance %s", instance)
 
 			// master specific validation
 			if instance == cloudSqlT.GetStringOutput("instance_name") {
 				// assert general database settings
 				assert.Equal("REGIONAL", op.Get("settings.availabilityType").String(), "Expected REGIONAL availabilityType")
 				assert.Equal(op.Get("settings.ipConfiguration.sslMode").String(), "ENCRYPTED_ONLY")
+
+				users := gcloud.Runf(t, "sql users list --instance %s --project %s", instance, projectId)
+				iamGroupFound := false
+				for _, u := range users.Array() {
+					if u.Get("name").String() == iamGroupEmail && u.Get("type").String() == "CLOUD_IAM_GROUP" {
+						iamGroupFound = true
+						break
+					}
+				}
+				assert.True(iamGroupFound, "Expected CLOUD_IAM_GROUP user %s on primary instance %s", iamGroupEmail, instance)
 
 				// replica specific validation
 			} else {


### PR DESCRIPTION
## Description
The purpose of this change is to enable IAM authentication towards Cloud SQL databases by default. Additionally, there has been added support for providing a list of IAM groups whom to the list of database users.

Fixes #81. 

## Notes
The version requirement for the `hashicorp/google` provider has been changed from `>=5` to `>=5.12.0`, as support for the `CLOUD_IAM_GROUP` type was first introduced in the latter version.